### PR TITLE
Remove unsafe block

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -210,7 +210,7 @@ fn decode_into(input: &[u8], output: &mut [u8], alpha: &[u8; 58]) -> Result<usiz
         if *c > 127 {
             return Err(Error::NonAsciiCharacter { index: i });
         }
-        let mut val = unsafe { *alpha.get_unchecked(*c as usize) as usize };
+        let mut val = alpha[*c as usize] as usize;
         if val == 0xFF {
             return Err(Error::InvalidCharacter {
                 character: *c as char,


### PR DESCRIPTION
fixes #7 

Full benchmark for decode without external libs:
```
empty/decode_bs58       time:   [39.107 ns 39.594 ns 40.181 ns]                               
                        change: [-1.8346% +0.0392% +1.8929%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe
empty/decode_bs58_noalloc_slice                                                                             
                        time:   [34.885 ns 35.409 ns 36.051 ns]
                        change: [-20.603% -18.954% -17.350%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) high mild
  11 (11.00%) high severe
empty/decode_bs58_noalloc_array                                                                             
                        time:   [35.045 ns 35.576 ns 36.211 ns]
                        change: [-19.771% -18.193% -16.415%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

1_byte/decode_bs58      time:   [87.765 ns 88.870 ns 90.214 ns]                               
                        change: [-1.4428% +0.0293% +1.4679%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
1_byte/decode_bs58_noalloc_slice                                                                             
                        time:   [39.557 ns 40.077 ns 40.734 ns]
                        change: [-0.7383% +1.9152% +5.6076%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
1_byte/decode_bs58_noalloc_array                                                                             
                        time:   [39.416 ns 39.906 ns 40.502 ns]
                        change: [-2.2775% -0.4735% +1.1687%] (p = 0.61 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

5_bytes/decode_bs58     time:   [105.95 ns 107.28 ns 108.91 ns]                                
                        change: [-1.3792% +0.1292% +1.5512%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
5_bytes/decode_bs58_noalloc_slice                                                                            
                        time:   [59.836 ns 60.529 ns 61.404 ns]
                        change: [-1.0832% +1.9020% +6.0046%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
5_bytes/decode_bs58_noalloc_array                                                                            
                        time:   [60.752 ns 61.536 ns 62.480 ns]
                        change: [-1.0733% +0.7263% +2.6161%] (p = 0.45 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

10_bytes/decode_bs58    time:   [144.59 ns 146.40 ns 148.64 ns]                                 
                        change: [-4.2179% -1.5186% +0.7587%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
10_bytes/decode_bs58_noalloc_slice                                                                            
                        time:   [98.736 ns 100.11 ns 101.77 ns]
                        change: [-2.3204% -0.5461% +1.1874%] (p = 0.53 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
10_bytes/decode_bs58_noalloc_array                                                                            
                        time:   [100.10 ns 101.52 ns 103.22 ns]
                        change: [-1.3300% +0.4599% +2.3087%] (p = 0.62 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

10_bytes_zero/decode_bs58                                                                            
                        time:   [107.14 ns 108.32 ns 109.83 ns]
                        change: [-2.8077% -0.5060% +1.4261%] (p = 0.68 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
10_bytes_zero/decode_bs58_noalloc_slice                                                                            
                        time:   [61.577 ns 62.339 ns 63.281 ns]
                        change: [-3.0841% -0.6944% +1.3042%] (p = 0.58 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
10_bytes_zero/decode_bs58_noalloc_array                                                                            
                        time:   [61.844 ns 62.760 ns 63.899 ns]
                        change: [-3.9917% -2.2971% -0.6159%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

10_bytes_max/decode_bs58                                                                            
                        time:   [144.66 ns 146.25 ns 148.28 ns]
                        change: [-1.7085% +0.0860% +1.8817%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe
10_bytes_max/decode_bs58_noalloc_slice                                                                            
                        time:   [99.237 ns 100.38 ns 101.77 ns]
                        change: [-1.0946% +0.7512% +2.4786%] (p = 0.43 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
10_bytes_max/decode_bs58_noalloc_array                                                                            
                        time:   [99.406 ns 100.54 ns 101.91 ns]
                        change: [-1.8580% +0.0545% +2.0436%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

32_bytes/decode_bs58    time:   [513.47 ns 519.43 ns 527.03 ns]                                  
                        change: [-3.4808% -0.3845% +2.3263%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) high mild
  14 (14.00%) high severe
32_bytes/decode_bs58_noalloc_slice                                                                            
                        time:   [465.95 ns 471.46 ns 478.22 ns]
                        change: [-1.8175% -0.0152% +1.4756%] (p = 0.99 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
32_bytes/decode_bs58_noalloc_array                                                                            
                        time:   [464.39 ns 470.60 ns 478.59 ns]
                        change: [-1.0613% +0.8359% +2.9167%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe

256_bytes/decode_bs58   time:   [30.959 us 31.266 us 31.653 us]                                   
                        change: [-1.4658% +0.0207% +1.4971%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe
256_bytes/decode_bs58_noalloc_slice                                                                             
                        time:   [30.817 us 31.139 us 31.535 us]
                        change: [-1.3712% -0.0209% +1.2437%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
```