### PR TITLE
Use `take_while` instead `break` in `for` loop

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -233,14 +233,10 @@ fn decode_into(input: &[u8], output: &mut [u8], alpha: &[u8; 58]) -> Result<usiz
         }
     }
 
-    for c in input {
-        if *c == zero {
-            let byte = output.get_mut(index).ok_or(Error::BufferTooSmall)?;
-            *byte = 0;
-            index += 1;
-        } else {
-            break;
-        }
+    for _ in input.iter().take_while(|c| **c == zero) {
+        let byte = output.get_mut(index).ok_or(Error::BufferTooSmall)?;
+        *byte = 0;
+        index += 1;
     }
 
     output[..index].reverse();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -210,25 +210,26 @@ fn decode_into(input: &[u8], output: &mut [u8], alpha: &[u8; 58]) -> Result<usiz
         if *c > 127 {
             return Err(Error::NonAsciiCharacter { index: i });
         }
+
         let mut val = alpha[*c as usize] as usize;
         if val == 0xFF {
             return Err(Error::InvalidCharacter {
                 character: *c as char,
                 index: i,
             });
-        } else {
-            for byte in &mut output[..index] {
-                val += (*byte as usize) * 58;
-                *byte = (val & 0xFF) as u8;
-                val >>= 8;
-            }
+        }
 
-            while val > 0 {
-                let byte = output.get_mut(index).ok_or(Error::BufferTooSmall)?;
-                *byte = (val & 0xFF) as u8;
-                index += 1;
-                val >>= 8
-            }
+        for byte in &mut output[..index] {
+            val += (*byte as usize) * 58;
+            *byte = (val & 0xFF) as u8;
+            val >>= 8;
+        }
+
+        while val > 0 {
+            let byte = output.get_mut(index).ok_or(Error::BufferTooSmall)?;
+            *byte = (val & 0xFF) as u8;
+            index += 1;
+            val >>= 8
         }
     }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -325,16 +325,12 @@ where
         }
     }
 
-    for &val in input {
-        if val == 0 {
-            if index == output.len() {
-                return Err(Error::BufferTooSmall);
-            }
-            output[index] = 0;
-            index += 1;
-        } else {
-            break;
+    for _ in input.into_iter().take_while(|v| **v == 0) {
+        if index == output.len() {
+            return Err(Error::BufferTooSmall);
         }
+        output[index] = 0;
+        index += 1;
     }
 
     for val in &mut output[..index] {


### PR DESCRIPTION
Readability changes:
- with `take_while` we can remove extra condition in `for` loop
- remove extra `else` for early return