### PR TITLE
Add with_check_version to EncodeBuilder

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5,17 +5,11 @@ use core::fmt;
 #[cfg(feature = "alloc")]
 use alloc::{vec, vec::Vec};
 
+use crate::Check;
 #[cfg(feature = "check")]
 use crate::CHECKSUM_LEN;
 
 use crate::alphabet::{Alphabet, AlphabetCow};
-
-/// Possible check variants.
-enum Check {
-    Disabled,
-    #[cfg(feature = "check")]
-    Enabled(Option<u8>),
-}
 
 /// A builder for setting up the alphabet and output of a base58 decode.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,13 @@ pub mod encode;
 #[cfg(feature = "check")]
 const CHECKSUM_LEN: usize = 4;
 
+/// Possible check variants.
+enum Check {
+    Disabled,
+    #[cfg(feature = "check")]
+    Enabled(Option<u8>),
+}
+
 /// Setup decoder for the given string using the [default alphabet][].
 ///
 /// [default alphabet]: alphabet/constant.DEFAULT.html

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -48,6 +48,17 @@ fn test_encode_check() {
             );
             assert_eq!(s.as_bytes(), &bytes[..s.len()]);
             assert_eq!(&FILLER[s.len()..], &bytes[s.len()..]);
+
+            if !val.is_empty() {
+                assert_eq!(
+                    Ok(s.len()),
+                    bs58::encode(&val[1..])
+                        .with_check_version(val[0])
+                        .into(&mut bytes[..])
+                );
+                assert_eq!(s.as_bytes(), &bytes[..s.len()]);
+                assert_eq!(&FILLER[s.len()..], &bytes[s.len()..]);
+            }
         }
 
         {


### PR DESCRIPTION
Another proposal: add version to EncodeBuilder.

But last hour I fight with Iterator for `encode_into`:
```rust
error[E0277]: the trait bound `<I as core::iter::IntoIterator>::IntoIter: core::clone::Clone` is not satisfied
   --> src/encode.rs:368:17
    |
307 | fn encode_into<'a, I>(input: I, output: &mut [u8], alpha: &[u8; 58]) -> Result<usize>
    |    -----------
308 | where
309 |     I: Clone + IntoIterator<Item = &'a u8>,
    |        ----- required by this bound in `encode::encode_into`
...
368 |     encode_into(version.into_iter().chain(input.iter()).chain(checksum.iter()), output, alpha)
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 expected an implementor of trait `core::clone::Clone`
    |                 help: consider borrowing here: `&version.into_iter().chain(input.iter()).chain(checksum.iter())`
    |
    = note: required because of the requirements on the impl of `core::clone::Clone` for `core::iter::Chain<<I as core::iter::IntoIterator>::IntoIter, core::slice::Iter<'_, u8>>`
    = note: required because of the requirements on the impl of `core::clone::Clone` for `core::iter::Chain<core::iter::Chain<<I as core::iter::IntoIterator>::IntoIter, core::slice::Iter<'_, u8>>, core::slice::Iter<'_, u8>>`
```

@Nemo157 any ideas?