### PR TITLE
Prepare for 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bs58"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 description = "Another Base58 codec implementation."
 repository = "https://github.com/mycorrhiza/bs58-rs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,5 @@ path = "src/main.rs"
 
 [dependencies]
 bs58 = { version = "0.4.0", path = ".." }
-paw = { version = "1.0.0", default-features = false }
-structopt = { version = "0.3.0", default-features = false, features = ["paw", "color"] }
+structopt = { version = "0.3.0", default-features = false, features = ["color"] }
 anyhow = "1.0.26"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,4 +17,4 @@ path = "src/main.rs"
 [dependencies]
 bs58 = { version = "0.4.0", path = ".." }
 structopt = { version = "0.3.0", default-features = false, features = ["color"] }
-anyhow = "1.0.26"
+anyhow = { version = "1.0.26", default-features = false, features = ["std"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "bs58"
 path = "src/main.rs"
 
 [dependencies]
-bs58 = { version = "0.3.0", path = ".." }
+bs58 = { version = "0.4.0", path = ".." }
 paw = { version = "1.0.0", default-features = false }
 structopt = { version = "0.3.0", default-features = false, features = ["paw", "color"] }
 anyhow = "1.0.26"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bs58-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 edition = "2018"
 description = """

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -51,7 +51,7 @@ impl FromStr for Alphabet {
                 //     let bytes = bytes
                 //         .try_into()
                 //         .context("custom alphabet is not 58 characters long")?;
-                Alphabet::Custom(bs58::Alphabet::new(bytes))
+                Alphabet::Custom(bs58::Alphabet::new(bytes)?)
             }
             other => {
                 return Err(anyhow!("'{}' is not a known alphabet", other));

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,10 +16,10 @@ enum Alphabet {
 impl Alphabet {
     fn as_alphabet(&self) -> &bs58::Alphabet {
         match self {
-            Alphabet::Bitcoin => bs58::Alphabet::BITCOIN,
-            Alphabet::Monero => bs58::Alphabet::MONERO,
-            Alphabet::Ripple => bs58::Alphabet::RIPPLE,
-            Alphabet::Flickr => bs58::Alphabet::FLICKR,
+            Alphabet::Bitcoin => &bs58::Alphabet::BITCOIN,
+            Alphabet::Monero => &bs58::Alphabet::MONERO,
+            Alphabet::Ripple => &bs58::Alphabet::RIPPLE,
+            Alphabet::Flickr => &bs58::Alphabet::FLICKR,
             Alphabet::Custom(custom) => custom,
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use std::{
+    convert::TryInto,
     fmt,
     io::{self, Read, Write},
     str::FromStr,
@@ -10,16 +11,16 @@ enum Alphabet {
     Monero,
     Ripple,
     Flickr,
-    Custom([u8; 58]),
+    Custom(bs58::Alphabet),
 }
 
 impl Alphabet {
-    fn as_bytes(&self) -> &[u8; 58] {
+    fn as_alphabet(&self) -> &bs58::Alphabet {
         match self {
-            Alphabet::Bitcoin => bs58::alphabet::BITCOIN,
-            Alphabet::Monero => bs58::alphabet::MONERO,
-            Alphabet::Ripple => bs58::alphabet::RIPPLE,
-            Alphabet::Flickr => bs58::alphabet::FLICKR,
+            Alphabet::Bitcoin => bs58::Alphabet::BITCOIN,
+            Alphabet::Monero => bs58::Alphabet::MONERO,
+            Alphabet::Ripple => bs58::Alphabet::RIPPLE,
+            Alphabet::Flickr => bs58::Alphabet::FLICKR,
             Alphabet::Custom(custom) => custom,
         }
     }
@@ -40,11 +41,10 @@ impl FromStr for Alphabet {
                 if bytes.iter().any(|&c| c > 128) {
                     return Err(anyhow!("custom alphabet must be ASCII characters only"));
                 }
-                if bytes.len() != 58 {
-                    return Err(anyhow!("custom alphabet is not 58 characters long"));
-                }
-                let ptr = bytes.as_ptr() as *const [u8; 58];
-                Alphabet::Custom(unsafe { *ptr })
+                let bytes = bytes
+                    .try_into()
+                    .context("custom alphabet is not 58 characters long")?;
+                Alphabet::Custom(bs58::Alphabet::new(bytes))
             }
             other => {
                 return Err(anyhow!("'{}' is not a known alphabet", other));
@@ -60,7 +60,7 @@ impl fmt::Debug for Alphabet {
             Alphabet::Monero => f.debug_tuple("Bitcoin").finish(),
             Alphabet::Ripple => f.debug_tuple("Bitcoin").finish(),
             Alphabet::Flickr => f.debug_tuple("Bitcoin").finish(),
-            Alphabet::Custom(custom) => f.debug_tuple("Custom").field(&&custom[..]).finish(),
+            Alphabet::Custom(custom) => f.debug_tuple("Custom").field(custom).finish(),
         }
     }
 }
@@ -87,14 +87,14 @@ fn main(args: Args) -> anyhow::Result<()> {
         io::stdin().read_to_string(&mut input)?;
         let trimmed = input.trim_end();
         let output = bs58::decode(trimmed)
-            .with_alphabet(args.alphabet.as_bytes())
+            .with_alphabet(args.alphabet.as_alphabet())
             .into_vec()?;
         io::stdout().write_all(&output)?;
     } else {
         let mut input = Vec::with_capacity(INITIAL_INPUT_CAPACITY);
         io::stdin().read_to_end(&mut input)?;
         let output = bs58::encode(input)
-            .with_alphabet(args.alphabet.as_bytes())
+            .with_alphabet(args.alphabet.as_alphabet())
             .into_string();
         io::stdout().write_all(output.as_bytes())?;
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,11 @@
-use anyhow::anyhow;
-use std::{
-    fmt,
-    io::{self, Read, Write},
-    str::FromStr,
+use ::{
+    anyhow::anyhow,
+    std::{
+        fmt,
+        io::{self, Read, Write},
+        str::FromStr,
+    },
+    structopt::StructOpt,
 };
 
 enum Alphabet {
@@ -72,7 +75,7 @@ impl fmt::Debug for Alphabet {
     }
 }
 
-#[derive(Debug, structopt::StructOpt)]
+#[derive(Debug, StructOpt)]
 #[structopt(name = "bs58", setting = structopt::clap::AppSettings::ColoredHelp)]
 /// A utility for encoding/decoding base58 encoded data.
 struct Args {
@@ -87,8 +90,10 @@ struct Args {
 }
 
 const INITIAL_INPUT_CAPACITY: usize = 4096;
-#[paw::main]
-fn main(args: Args) -> anyhow::Result<()> {
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::from_iter_safe(std::env::args_os())?;
+
     if args.decode {
         let mut input = String::with_capacity(INITIAL_INPUT_CAPACITY);
         io::stdin().read_to_string(&mut input)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,5 @@
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use std::{
-    convert::TryInto,
     fmt,
     io::{self, Read, Write},
     str::FromStr,
@@ -41,9 +40,17 @@ impl FromStr for Alphabet {
                 if bytes.iter().any(|&c| c > 128) {
                     return Err(anyhow!("custom alphabet must be ASCII characters only"));
                 }
-                let bytes = bytes
-                    .try_into()
-                    .context("custom alphabet is not 58 characters long")?;
+                if bytes.len() != 58 {
+                    return Err(anyhow!("custom alphabet is not 58 characters long"));
+                }
+                // SAFETY: Length checked just above
+                let bytes = unsafe { &*(bytes.as_ptr().cast::<[u8; 58]>()) };
+                // TODO:
+                //     use std::convert::TryInto;
+                //     use anyhow::Context;
+                //     let bytes = bytes
+                //         .try_into()
+                //         .context("custom alphabet is not 58 characters long")?;
                 Alphabet::Custom(bs58::Alphabet::new(bytes))
             }
             other => {

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,10 +1,9 @@
 use std::io::{self, Read, Write};
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut input = String::new();
-    io::stdin().read_to_string(&mut input).unwrap();
-    match bs58::decode(input.trim()).into_vec() {
-        Ok(vec) => io::stdout().write_all(&*vec).unwrap(),
-        Err(err) => eprintln!("{}", err),
-    };
+    io::stdin().read_to_string(&mut input)?;
+    let data = &bs58::decode(input.trim()).into_vec()?;
+    io::stdout().write_all(&data)?;
+    Ok(())
 }

--- a/examples/encode.rs
+++ b/examples/encode.rs
@@ -1,7 +1,8 @@
 use std::io::{self, Read};
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut input = Vec::<u8>::new();
-    io::stdin().read_to_end(&mut input).unwrap();
+    io::stdin().read_to_end(&mut input)?;
     println!("{}", bs58::encode(input).into_string());
+    Ok(())
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -146,7 +146,7 @@ impl Alphabet {
     /// ```
     ///
     /// If your alphabet is inconsistent then this will fail to compile in a `const` context:
-    /// 
+    ///
     /// ```compile_fail
     /// const _: bs58::Alphabet = bs58::Alphabet::new_unwrap(
     ///     b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -154,18 +154,11 @@ impl Alphabet {
     /// ```
     pub const fn new_unwrap(base: &[u8; 58]) -> Self {
         let result = Self::new(base);
-        let _ = [0][match result {
-            Ok(_) => 0,
-            Err(_) => 1,
-        }];
-        match result {
-            Ok(alphabet) => alphabet,
-            // unreachable, for type checking
-            Err(_) => Self {
-                encode: [0; 58],
-                decode: [0; 128],
-            },
-        }
+        #[allow(unconditional_panic)] // that's the point
+        [][match result {
+            Ok(alphabet) => return alphabet,
+            Err(_) => 0,
+        }]
     }
 }
 

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,11 +1,129 @@
 use core::fmt;
 
-/// Prepared Alphabet for [`EncodeBuilder`](crate::encode::EncodeBuilder) and
-/// [`DecodeBuilder`](crate::decode::DecodeBuilder).
+/// Prepared Alphabet for
+/// [`EncodeBuilder::with_alphabet`](crate::encode::EncodeBuilder::with_alphabet) and
+/// [`DecodeBuilder::with_alphabet`](crate::decode::DecodeBuilder::with_alphabet).
 #[derive(Clone, Copy)]
 pub struct Alphabet {
     pub(crate) encode: [u8; 58],
     pub(crate) decode: [u8; 128],
+}
+
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    DuplicateCharacter {
+        character: char,
+        first: usize,
+        second: usize,
+    },
+    NonAsciiCharacter {
+        index: usize,
+    },
+}
+
+impl Alphabet {
+    /// Create prepared alphabet, checks that the alphabet is pure ASCII and that there are no
+    /// duplicate characters, which would result in inconsistent encoding/decoding
+    ///
+    /// ```rust
+    /// let alpha = bs58::Alphabet::new(
+    ///     b" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXY"
+    /// )?;
+    ///
+    /// let decoded = bs58::decode("he11owor1d")
+    ///     .with_alphabet(bs58::Alphabet::RIPPLE)
+    ///     .into_vec()?;
+    /// let encoded = bs58::encode(decoded)
+    ///     .with_alphabet(&alpha)
+    ///     .into_string();
+    ///
+    /// assert_eq!("#ERRN)N RD", encoded);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub const fn new(base: &[u8; 58]) -> Result<Self, Error> {
+        let mut encode = [0x00; 58];
+        let mut decode = [0xFF; 128];
+
+        let mut i = 0;
+        while i < encode.len() {
+            if base[i] >= 128 {
+                return Err(Error::NonAsciiCharacter { index: i });
+            }
+            if decode[base[i] as usize] != 0xFF {
+                return Err(Error::DuplicateCharacter {
+                    character: base[i] as char,
+                    first: decode[base[i] as usize] as usize,
+                    second: i,
+                });
+            }
+            encode[i] = base[i];
+            decode[base[i] as usize] = i as u8;
+            i += 1;
+        }
+
+        Ok(Self { encode, decode })
+    }
+
+    /// Same as [`Self::new`], but gives a panic instead of an [`Err`] on bad input.
+    ///
+    /// Intended to support usage in `const` context until [`Result::unwrap`] is able to be called.
+    ///
+    /// ```rust
+    /// const ALPHA: bs58::Alphabet = bs58::Alphabet::new_unwrap(
+    ///     b" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXY"
+    /// );
+    ///
+    /// let decoded = bs58::decode("he11owor1d")
+    ///     .with_alphabet(bs58::Alphabet::RIPPLE)
+    ///     .into_vec()?;
+    /// let encoded = bs58::encode(decoded)
+    ///     .with_alphabet(&ALPHA)
+    ///     .into_string();
+    ///
+    /// assert_eq!("#ERRN)N RD", encoded);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub const fn new_unwrap(base: &[u8; 58]) -> Self {
+        let result = Self::new(base);
+        let _ = [0][result.is_err() as usize];
+        match result {
+            Ok(alphabet) => alphabet,
+            // unreachable, for type checking
+            Err(_) => Self {
+                encode: [0; 58],
+                decode: [0; 128],
+            },
+        }
+    }
+
+    /// Bitcoin's alphabet as defined in their Base58Check encoding.
+    ///
+    /// See <https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart>
+    pub const BITCOIN: &'static Self =
+        &Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+
+    /// Monero's alphabet as defined in this forum post.
+    ///
+    /// See <https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins>
+    pub const MONERO: &'static Self =
+        &Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+
+    /// Ripple's alphabet as defined in their wiki.
+    ///
+    /// See <https://wiki.ripple.com/Encodings>
+    pub const RIPPLE: &'static Self =
+        &Self::new_unwrap(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
+
+    /// Flickr's alphabet for creating short urls from photo ids.
+    ///
+    /// See <https://www.flickr.com/groups/api/discuss/72157616713786392/>
+    pub const FLICKR: &'static Self =
+        &Self::new_unwrap(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
+
+    /// The default alphabet used if none is given. Currently is the
+    /// [`BITCOIN`](Self::BITCOIN) alphabet.
+    pub const DEFAULT: &'static Self = Self::BITCOIN;
 }
 
 impl fmt::Debug for Alphabet {
@@ -13,54 +131,32 @@ impl fmt::Debug for Alphabet {
         if let Ok(s) = core::str::from_utf8(&self.encode) {
             f.debug_tuple("Alphabet").field(&s).finish()
         } else {
-            f.debug_tuple("Alphabet").field(&&self.encode[..]).finish()
+            unreachable!()
         }
     }
 }
 
-impl Alphabet {
-    /// Create prepared alphabet.
-    pub const fn new(base: &[u8; 58]) -> Alphabet {
-        let mut encode = [0x00; 58];
-        let mut decode = [0xFF; 128];
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {}
 
-        let mut i = 0;
-        while i < encode.len() {
-            encode[i] = base[i];
-            decode[base[i] as usize] = i as u8;
-            i += 1;
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::DuplicateCharacter {
+                character,
+                first,
+                second,
+            } => write!(
+                f,
+                "alphabet contained a duplicate character `{}` at indexes {} and {}",
+                character, first, second,
+            ),
+            Error::NonAsciiCharacter { index } => {
+                write!(f, "alphabet contained a non-ascii character at {}", index)
+            }
         }
-
-        Alphabet { encode, decode }
     }
-
-    /// Bitcoin's alphabet as defined in their Base58Check encoding.
-    ///
-    /// See <https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart>
-    pub const BITCOIN: &'static Self =
-        &Self::new(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
-
-    /// Monero's alphabet as defined in this forum post.
-    ///
-    /// See <https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins>
-    pub const MONERO: &'static Self =
-        &Self::new(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
-
-    /// Ripple's alphabet as defined in their wiki.
-    ///
-    /// See <https://wiki.ripple.com/Encodings>
-    pub const RIPPLE: &'static Self =
-        &Self::new(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
-
-    /// Flickr's alphabet for creating short urls from photo ids.
-    ///
-    /// See <https://www.flickr.com/groups/api/discuss/72157616713786392/>
-    pub const FLICKR: &'static Self =
-        &Self::new(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
-
-    /// The default alphabet used if none is given. Currently is the
-    /// [`BITCOIN`](Self::BITCOIN) alphabet.
-    pub const DEFAULT: &'static Self = Self::BITCOIN;
 }
 
 // Force evaluation of the associated constants to make sure they don't error

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -32,7 +32,7 @@ impl Alphabet {
     /// )?;
     ///
     /// let decoded = bs58::decode("he11owor1d")
-    ///     .with_alphabet(bs58::Alphabet::RIPPLE)
+    ///     .with_alphabet(&bs58::Alphabet::RIPPLE)
     ///     .into_vec()?;
     /// let encoded = bs58::encode(decoded)
     ///     .with_alphabet(&alpha)
@@ -75,7 +75,7 @@ impl Alphabet {
     /// );
     ///
     /// let decoded = bs58::decode("he11owor1d")
-    ///     .with_alphabet(bs58::Alphabet::RIPPLE)
+    ///     .with_alphabet(&bs58::Alphabet::RIPPLE)
     ///     .into_vec()?;
     /// let encoded = bs58::encode(decoded)
     ///     .with_alphabet(&ALPHA)
@@ -100,30 +100,30 @@ impl Alphabet {
     /// Bitcoin's alphabet as defined in their Base58Check encoding.
     ///
     /// See <https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart>
-    pub const BITCOIN: &'static Self =
-        &Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+    pub const BITCOIN: Self =
+        Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
 
     /// Monero's alphabet as defined in this forum post.
     ///
     /// See <https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins>
-    pub const MONERO: &'static Self =
-        &Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+    pub const MONERO: Self =
+        Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
 
     /// Ripple's alphabet as defined in their wiki.
     ///
     /// See <https://wiki.ripple.com/Encodings>
-    pub const RIPPLE: &'static Self =
-        &Self::new_unwrap(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
+    pub const RIPPLE: Self =
+        Self::new_unwrap(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
 
     /// Flickr's alphabet for creating short urls from photo ids.
     ///
     /// See <https://www.flickr.com/groups/api/discuss/72157616713786392/>
-    pub const FLICKR: &'static Self =
-        &Self::new_unwrap(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
+    pub const FLICKR: Self =
+        Self::new_unwrap(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
 
     /// The default alphabet used if none is given. Currently is the
     /// [`BITCOIN`](Self::BITCOIN) alphabet.
-    pub const DEFAULT: &'static Self = Self::BITCOIN;
+    pub const DEFAULT: Self = Self::BITCOIN;
 }
 
 impl fmt::Debug for Alphabet {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,30 +1,4 @@
-//! Commonly used Base58 alphabets.
-
-/// Bitcoin's alphabet as defined in their Base58Check encoding.
-///
-/// See https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart.
-pub const BITCOIN: &[u8; 58] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
-/// Monero's alphabet as defined in this forum post.
-///
-/// See https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins
-pub const MONERO: &[u8; 58] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
-/// Ripple's alphabet as defined in their wiki.
-///
-/// See https://wiki.ripple.com/Encodings
-pub const RIPPLE: &[u8; 58] = b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz";
-
-/// Flickr's alphabet for creating short urls from photo ids.
-///
-/// See https://www.flickr.com/groups/api/discuss/72157616713786392/
-pub const FLICKR: &[u8; 58] = b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
-
-/// The default alphabet used if none is given. Currently is the
-/// [`BITCOIN`](constant.BITCOIN.html) alphabet.
-pub const DEFAULT: &[u8; 58] = BITCOIN;
-
-/// Prepared Alpabet for [`EncodeBuilder`](crate::encode::EncodeBuilder) and [`DecodeBuilder`](crate::decode::DecodeBuilder).
+/// Prepared Alphabet for [`EncodeBuilder`](crate::encode::EncodeBuilder) and [`DecodeBuilder`](crate::decode::DecodeBuilder).
 #[derive(Clone, Copy)]
 #[allow(missing_debug_implementations)]
 pub struct Alphabet {
@@ -33,18 +7,6 @@ pub struct Alphabet {
 }
 
 impl Alphabet {
-    /// Bitcoin's prepared alphabet.
-    pub const BITCOIN: &'static Self = &Self::new(BITCOIN);
-    /// Monero's prepared alphabet.
-    pub const MONERO: &'static Self = &Self::new(MONERO);
-    /// Ripple's prepared alphabet.
-    pub const RIPPLE: &'static Self = &Self::new(RIPPLE);
-    /// Flickr's prepared alphabet.
-    pub const FLICKR: &'static Self = &Self::new(FLICKR);
-    /// The default prepared alphabet used if none is given. Currently is the
-    /// [`Alphabet::Bitcoin`](Alphabet::BITCOIN) alphabet.
-    pub const DEFAULT: &'static Self = Self::BITCOIN;
-
     /// Create prepared alphabet.
     pub const fn new(base: &[u8; 58]) -> Alphabet {
         let mut encode = [0x00; 58];
@@ -59,11 +21,41 @@ impl Alphabet {
 
         Alphabet { encode, decode }
     }
+
+    /// Bitcoin's alphabet as defined in their Base58Check encoding.
+    ///
+    /// See <https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart>
+    pub const BITCOIN: &'static Self =
+        &Self::new(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+
+    /// Monero's alphabet as defined in this forum post.
+    ///
+    /// See <https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins>
+    pub const MONERO: &'static Self =
+        &Self::new(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+
+    /// Ripple's alphabet as defined in their wiki.
+    ///
+    /// See <https://wiki.ripple.com/Encodings>
+    pub const RIPPLE: &'static Self =
+        &Self::new(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
+
+    /// Flickr's alphabet for creating short urls from photo ids.
+    ///
+    /// See <https://www.flickr.com/groups/api/discuss/72157616713786392/>
+    pub const FLICKR: &'static Self =
+        &Self::new(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
+
+    /// The default alphabet used if none is given. Currently is the
+    /// [`BITCOIN`](Self::BITCOIN) alphabet.
+    pub const DEFAULT: &'static Self = Self::BITCOIN;
 }
 
-/// `std::borrow::Cow` alternative.
-#[allow(variant_size_differences)]
-pub(crate) enum AlphabetCow<'a> {
-    Borrowed(&'a Alphabet),
-    Owned(Alphabet),
-}
+// Force evaluation of the associated constants to make sure they don't error
+const _: () = {
+    let _ = Alphabet::BITCOIN;
+    let _ = Alphabet::MONERO;
+    let _ = Alphabet::RIPPLE;
+    let _ = Alphabet::FLICKR;
+    let _ = Alphabet::DEFAULT;
+};

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,3 +1,5 @@
+//! Support for configurable alphabets
+
 use core::fmt;
 
 /// Prepared Alphabet for
@@ -9,15 +11,23 @@ pub struct Alphabet {
     pub(crate) decode: [u8; 128],
 }
 
+/// Errors that could occur when preparing a Base58 alphabet.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// The alphabet contained a duplicate character at at least 2 indexes.
     DuplicateCharacter {
+        /// The duplicate character encountered.
         character: char,
+        /// The first index the character was seen at.
         first: usize,
+        /// The second index the character was seen at.
         second: usize,
     },
+
+    /// The alphabet contained a multi-byte (or non-utf8) character.
     NonAsciiCharacter {
+        /// The index at which the non-ASCII character was seen.
         index: usize,
     },
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -23,6 +23,36 @@ pub enum Error {
 }
 
 impl Alphabet {
+    /// The default alphabet used if none is given. Currently is the
+    /// [`BITCOIN`](Self::BITCOIN) alphabet.
+    pub const DEFAULT: Self = Self::BITCOIN;
+
+    /// Bitcoin's alphabet as defined in their Base58Check encoding.
+    ///
+    /// See <https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart>
+    pub const BITCOIN: Self =
+        Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+
+    /// Monero's alphabet as defined in this forum post.
+    ///
+    /// See <https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins>
+    pub const MONERO: Self =
+        Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+
+    /// Ripple's alphabet as defined in their wiki.
+    ///
+    /// See <https://wiki.ripple.com/Encodings>
+    pub const RIPPLE: Self =
+        Self::new_unwrap(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
+
+    /// Flickr's alphabet for creating short urls from photo ids.
+    ///
+    /// See <https://www.flickr.com/groups/api/discuss/72157616713786392/>
+    pub const FLICKR: Self =
+        Self::new_unwrap(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
+}
+
+impl Alphabet {
     /// Create prepared alphabet, checks that the alphabet is pure ASCII and that there are no
     /// duplicate characters, which would result in inconsistent encoding/decoding
     ///
@@ -96,34 +126,6 @@ impl Alphabet {
             },
         }
     }
-
-    /// Bitcoin's alphabet as defined in their Base58Check encoding.
-    ///
-    /// See <https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart>
-    pub const BITCOIN: Self =
-        Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
-
-    /// Monero's alphabet as defined in this forum post.
-    ///
-    /// See <https://forum.getmonero.org/4/academic-and-technical/221/creating-a-standard-for-physical-coins>
-    pub const MONERO: Self =
-        Self::new_unwrap(b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
-
-    /// Ripple's alphabet as defined in their wiki.
-    ///
-    /// See <https://wiki.ripple.com/Encodings>
-    pub const RIPPLE: Self =
-        Self::new_unwrap(b"rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz");
-
-    /// Flickr's alphabet for creating short urls from photo ids.
-    ///
-    /// See <https://www.flickr.com/groups/api/discuss/72157616713786392/>
-    pub const FLICKR: Self =
-        Self::new_unwrap(b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ");
-
-    /// The default alphabet used if none is given. Currently is the
-    /// [`BITCOIN`](Self::BITCOIN) alphabet.
-    pub const DEFAULT: Self = Self::BITCOIN;
 }
 
 impl fmt::Debug for Alphabet {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,9 +1,20 @@
+use core::fmt;
+
 /// Prepared Alphabet for [`EncodeBuilder`](crate::encode::EncodeBuilder) and [`DecodeBuilder`](crate::decode::DecodeBuilder).
 #[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
 pub struct Alphabet {
     pub(crate) encode: [u8; 58],
     pub(crate) decode: [u8; 128],
+}
+
+impl fmt::Debug for Alphabet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Ok(s) = core::str::from_utf8(&self.encode) {
+            f.debug_tuple("Alphabet").field(&s).finish()
+        } else {
+            f.debug_tuple("Alphabet").field(&self.encode).finish()
+        }
+    }
 }
 
 impl Alphabet {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -47,76 +47,15 @@ impl Alphabet {
 
     /// Create prepared alphabet.
     pub const fn new(base: &[u8; 58]) -> Alphabet {
-        let encode = [
-            base[0], base[1], base[2], base[3], base[4], base[5], base[6], base[7], base[8],
-            base[9], base[10], base[11], base[12], base[13], base[14], base[15], base[16],
-            base[17], base[18], base[19], base[20], base[21], base[22], base[23], base[24],
-            base[25], base[26], base[27], base[28], base[29], base[30], base[31], base[32],
-            base[33], base[34], base[35], base[36], base[37], base[38], base[39], base[40],
-            base[41], base[42], base[43], base[44], base[45], base[46], base[47], base[48],
-            base[49], base[50], base[51], base[52], base[53], base[54], base[55], base[56],
-            base[57],
-        ];
-
+        let mut encode = [0x00; 58];
         let mut decode = [0xFF; 128];
-        decode[base[0] as usize] = 0;
-        decode[base[1] as usize] = 1;
-        decode[base[2] as usize] = 2;
-        decode[base[3] as usize] = 3;
-        decode[base[4] as usize] = 4;
-        decode[base[5] as usize] = 5;
-        decode[base[6] as usize] = 6;
-        decode[base[7] as usize] = 7;
-        decode[base[8] as usize] = 8;
-        decode[base[9] as usize] = 9;
-        decode[base[10] as usize] = 10;
-        decode[base[11] as usize] = 11;
-        decode[base[12] as usize] = 12;
-        decode[base[13] as usize] = 13;
-        decode[base[14] as usize] = 14;
-        decode[base[15] as usize] = 15;
-        decode[base[16] as usize] = 16;
-        decode[base[17] as usize] = 17;
-        decode[base[18] as usize] = 18;
-        decode[base[19] as usize] = 19;
-        decode[base[20] as usize] = 20;
-        decode[base[21] as usize] = 21;
-        decode[base[22] as usize] = 22;
-        decode[base[23] as usize] = 23;
-        decode[base[24] as usize] = 24;
-        decode[base[25] as usize] = 25;
-        decode[base[26] as usize] = 26;
-        decode[base[27] as usize] = 27;
-        decode[base[28] as usize] = 28;
-        decode[base[29] as usize] = 29;
-        decode[base[30] as usize] = 30;
-        decode[base[31] as usize] = 31;
-        decode[base[32] as usize] = 32;
-        decode[base[33] as usize] = 33;
-        decode[base[34] as usize] = 34;
-        decode[base[35] as usize] = 35;
-        decode[base[36] as usize] = 36;
-        decode[base[37] as usize] = 37;
-        decode[base[38] as usize] = 38;
-        decode[base[39] as usize] = 39;
-        decode[base[40] as usize] = 40;
-        decode[base[41] as usize] = 41;
-        decode[base[42] as usize] = 42;
-        decode[base[43] as usize] = 43;
-        decode[base[44] as usize] = 44;
-        decode[base[45] as usize] = 45;
-        decode[base[46] as usize] = 46;
-        decode[base[47] as usize] = 47;
-        decode[base[48] as usize] = 48;
-        decode[base[49] as usize] = 49;
-        decode[base[50] as usize] = 50;
-        decode[base[51] as usize] = 51;
-        decode[base[52] as usize] = 52;
-        decode[base[53] as usize] = 53;
-        decode[base[54] as usize] = 54;
-        decode[base[55] as usize] = 55;
-        decode[base[56] as usize] = 56;
-        decode[base[57] as usize] = 57;
+
+        let mut i = 0;
+        while i < encode.len() {
+            encode[i] = base[i];
+            decode[base[i] as usize] = i as u8;
+            i += 1;
+        }
 
         Alphabet { encode, decode }
     }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
-/// Prepared Alphabet for [`EncodeBuilder`](crate::encode::EncodeBuilder) and [`DecodeBuilder`](crate::decode::DecodeBuilder).
+/// Prepared Alphabet for [`EncodeBuilder`](crate::encode::EncodeBuilder) and
+/// [`DecodeBuilder`](crate::decode::DecodeBuilder).
 #[derive(Clone, Copy)]
 pub struct Alphabet {
     pub(crate) encode: [u8; 58],

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -13,7 +13,7 @@ impl fmt::Debug for Alphabet {
         if let Ok(s) = core::str::from_utf8(&self.encode) {
             f.debug_tuple("Alphabet").field(&s).finish()
         } else {
-            f.debug_tuple("Alphabet").field(&self.encode).finish()
+            f.debug_tuple("Alphabet").field(&&self.encode[..]).finish()
         }
     }
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -116,7 +116,10 @@ impl Alphabet {
     /// ```
     pub const fn new_unwrap(base: &[u8; 58]) -> Self {
         let result = Self::new(base);
-        let _ = [0][result.is_err() as usize];
+        let _ = [0][match result {
+            Ok(_) => 0,
+            Err(_) => 1,
+        }];
         match result {
             Ok(alphabet) => alphabet,
             // unreachable, for type checking

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -138,7 +138,7 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
 
     /// Decode into a new vector of bytes.
     ///
-    /// See the documentation for [`bs58::decode`](../fn.decode.html) for an
+    /// See the documentation for [`bs58::decode`](crate::decode()) for an
     /// explanation of the errors that may occur.
     ///
     /// # Examples
@@ -165,7 +165,7 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     /// Returns the length written into the buffer, the rest of the bytes in
     /// the buffer will be untouched.
     ///
-    /// See the documentation for [`bs58::decode`](../fn.decode.html) for an
+    /// See the documentation for [`bs58::decode`](crate::decode()) for an
     /// explanation of the errors that may occur.
     ///
     /// # Examples

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -104,7 +104,8 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     ///     vec![0x60, 0x65, 0xe7, 0x9b, 0xba, 0x2f, 0x78],
     ///     bs58::decode("he11owor1d")
     ///         .with_alphabet(bs58::Alphabet::RIPPLE)
-    ///         .into_vec().unwrap());
+    ///         .into_vec()?);
+    /// # Ok::<(), bs58::decode::Error>(())
     /// ```
     pub fn with_alphabet(self, alpha: &'a Alphabet) -> DecodeBuilder<'a, I> {
         DecodeBuilder { alpha, ..self }
@@ -125,7 +126,8 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     ///     vec![0x2d, 0x31],
     ///     bs58::decode("PWEu9GGN")
     ///         .with_check(None)
-    ///         .into_vec().unwrap());
+    ///         .into_vec()?);
+    /// # Ok::<(), bs58::decode::Error>(())
     /// ```
     #[cfg(feature = "check")]
     #[cfg_attr(docsrs, doc(cfg(feature = "check")))]
@@ -144,7 +146,8 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     /// ```rust
     /// assert_eq!(
     ///     vec![0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58],
-    ///     bs58::decode("he11owor1d").into_vec().unwrap());
+    ///     bs58::decode("he11owor1d").into_vec()?);
+    /// # Ok::<(), bs58::decode::Error>(())
     /// ```
     ///
     #[cfg(feature = "alloc")]
@@ -169,10 +172,11 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     ///
     /// ```rust
     /// let mut output = [0xFF; 10];
-    /// assert_eq!(8, bs58::decode("he11owor1d").into(&mut output).unwrap());
+    /// assert_eq!(8, bs58::decode("he11owor1d").into(&mut output)?);
     /// assert_eq!(
     ///     [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58, 0xFF, 0xFF],
     ///     output);
+    /// # Ok::<(), bs58::decode::Error>(())
     /// ```
     pub fn into<O: AsMut<[u8]>>(self, mut output: O) -> Result<usize> {
         match self.check {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -90,7 +90,7 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     pub(crate) fn from_input(input: I) -> DecodeBuilder<'static, I> {
         DecodeBuilder {
             input,
-            alpha: Alphabet::DEFAULT,
+            alpha: &Alphabet::DEFAULT,
             check: Check::Disabled,
         }
     }
@@ -103,7 +103,7 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
     /// assert_eq!(
     ///     vec![0x60, 0x65, 0xe7, 0x9b, 0xba, 0x2f, 0x78],
     ///     bs58::decode("he11owor1d")
-    ///         .with_alphabet(bs58::Alphabet::RIPPLE)
+    ///         .with_alphabet(&bs58::Alphabet::RIPPLE)
     ///         .into_vec()?);
     /// # Ok::<(), bs58::decode::Error>(())
     /// ```

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -136,7 +136,7 @@ impl EncodeTarget for str {
 
 impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// Setup encoder for the given string using the given alphabet.
-    /// Preferably use [`bs58::encode`](../fn.encode.html) instead of this
+    /// Preferably use [`bs58::encode`](crate::encode()) instead of this
     /// directly.
     pub fn new(input: I, alpha: &'a Alphabet) -> EncodeBuilder<'a, I> {
         EncodeBuilder {
@@ -258,7 +258,7 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// up to 3 null bytes may be written to an `&mut str` to overwrite remaining characters of a
     /// partially overwritten multi-byte character.
     ///
-    /// See the documentation for [`bs58::encode`](../fn.encode.html) for an
+    /// See the documentation for [`bs58::encode`](crate::encode()) for an
     /// explanation of the errors that may occur.
     ///
     /// # Examples

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -268,8 +268,9 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// ```rust
     /// let input = [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58];
     /// let mut output = "goodbye world".to_owned().into_bytes();
-    /// bs58::encode(input).into(&mut output);
+    /// bs58::encode(input).into(&mut output)?;
     /// assert_eq!(b"he11owor1d", &*output);
+    /// # Ok::<(), bs58::encode::Error>(())
     /// ```
     ///
     /// ## `&mut [u8]`
@@ -277,8 +278,9 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// ```rust
     /// let input = [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58];
     /// let mut output = Vec::from("goodbye world");
-    /// bs58::encode(input).into(&mut output[..]);
+    /// bs58::encode(input).into(&mut output[..])?;
     /// assert_eq!(b"he11owor1drld", &*output);
+    /// # Ok::<(), bs58::encode::Error>(())
     /// ```
     ///
     /// ## `String`
@@ -286,8 +288,9 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// ```rust
     /// let input = [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58];
     /// let mut output = "goodbye world".to_owned();
-    /// bs58::encode(input).into(&mut output);
+    /// bs58::encode(input).into(&mut output)?;
     /// assert_eq!("he11owor1d", output);
+    /// # Ok::<(), bs58::encode::Error>(())
     /// ```
     ///
     /// ## `&mut str`
@@ -295,8 +298,9 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// ```rust
     /// let input = [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58];
     /// let mut output = "goodbye world".to_owned();
-    /// bs58::encode(input).into(output.as_mut_str());
+    /// bs58::encode(input).into(output.as_mut_str())?;
     /// assert_eq!("he11owor1drld", output);
+    /// # Ok::<(), bs58::encode::Error>(())
     /// ```
     ///
     /// ### Clearing partially overwritten characters
@@ -304,8 +308,9 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// ```rust
     /// let input = [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58];
     /// let mut output = "goodbye w®ld".to_owned();
-    /// bs58::encode(input).into(output.as_mut_str());
+    /// bs58::encode(input).into(output.as_mut_str())?;
     /// assert_eq!("he11owor1d\0ld", output);
+    /// # Ok::<(), bs58::encode::Error>(())
     /// ```
     pub fn into(self, mut output: impl EncodeTarget) -> Result<usize> {
         match self.check {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -150,7 +150,7 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     pub(crate) fn from_input(input: I) -> EncodeBuilder<'static, I> {
         EncodeBuilder {
             input,
-            alpha: Alphabet::DEFAULT,
+            alpha: &Alphabet::DEFAULT,
             check: Check::Disabled,
         }
     }
@@ -164,7 +164,7 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// assert_eq!(
     ///     "he11owor1d",
     ///     bs58::encode(input)
-    ///         .with_alphabet(bs58::Alphabet::RIPPLE)
+    ///         .with_alphabet(&bs58::Alphabet::RIPPLE)
     ///         .into_string());
     /// ```
     pub fn with_alphabet(self, alpha: &'a Alphabet) -> EncodeBuilder<'a, I> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -9,13 +9,13 @@ use crate::Check;
 #[cfg(feature = "check")]
 use crate::CHECKSUM_LEN;
 
-use crate::alphabet::{Alphabet, AlphabetCow};
+use crate::Alphabet;
 
 /// A builder for setting up the alphabet and output of a base58 encode.
 #[allow(missing_debug_implementations)]
 pub struct EncodeBuilder<'a, I: AsRef<[u8]>> {
     input: I,
-    alpha: AlphabetCow<'a>,
+    alpha: &'a Alphabet,
     check: Check,
 }
 
@@ -138,10 +138,10 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// Setup encoder for the given string using the given alphabet.
     /// Preferably use [`bs58::encode`](../fn.encode.html) instead of this
     /// directly.
-    pub fn new(input: I, alpha: &'a [u8; 58]) -> EncodeBuilder<'a, I> {
+    pub fn new(input: I, alpha: &'a Alphabet) -> EncodeBuilder<'a, I> {
         EncodeBuilder {
             input,
-            alpha: AlphabetCow::Owned(Alphabet::new(alpha)),
+            alpha,
             check: Check::Disabled,
         }
     }
@@ -150,7 +150,7 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     pub(crate) fn from_input(input: I) -> EncodeBuilder<'static, I> {
         EncodeBuilder {
             input,
-            alpha: AlphabetCow::Borrowed(Alphabet::DEFAULT),
+            alpha: Alphabet::DEFAULT,
             check: Check::Disabled,
         }
     }
@@ -164,28 +164,10 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     /// assert_eq!(
     ///     "he11owor1d",
     ///     bs58::encode(input)
-    ///         .with_alphabet(bs58::alphabet::RIPPLE)
+    ///         .with_alphabet(bs58::Alphabet::RIPPLE)
     ///         .into_string());
     /// ```
-    pub fn with_alphabet(self, alpha: &'a [u8; 58]) -> EncodeBuilder<'a, I> {
-        let alpha = AlphabetCow::Owned(Alphabet::new(alpha));
-        EncodeBuilder { alpha, ..self }
-    }
-
-    /// Change the alphabet that will be used for decoding.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let input = [0x60, 0x65, 0xe7, 0x9b, 0xba, 0x2f, 0x78];
-    /// assert_eq!(
-    ///     "he11owor1d",
-    ///     bs58::encode(input)
-    ///         .with_prepared_alphabet(bs58::Alphabet::RIPPLE)
-    ///         .into_string());
-    /// ```
-    pub fn with_prepared_alphabet(self, alpha: &'a Alphabet) -> EncodeBuilder<'a, I> {
-        let alpha = AlphabetCow::Borrowed(alpha);
+    pub fn with_alphabet(self, alpha: &'a Alphabet) -> EncodeBuilder<'a, I> {
         EncodeBuilder { alpha, ..self }
     }
 
@@ -344,15 +326,10 @@ impl<'a, I: AsRef<[u8]>> EncodeBuilder<'a, I> {
     }
 }
 
-fn encode_into<'a, I>(input: I, output: &mut [u8], alpha: &AlphabetCow) -> Result<usize>
+fn encode_into<'a, I>(input: I, output: &mut [u8], alpha: &Alphabet) -> Result<usize>
 where
     I: Clone + IntoIterator<Item = &'a u8>,
 {
-    let alpha = match alpha {
-        AlphabetCow::Borrowed(alpha) => alpha,
-        AlphabetCow::Owned(ref alpha) => alpha,
-    };
-
     let mut index = 0;
     for &val in input.clone() {
         let mut carry = val as usize;
@@ -391,7 +368,7 @@ where
 fn encode_check_into(
     input: &[u8],
     output: &mut [u8],
-    alpha: &AlphabetCow,
+    alpha: &Alphabet,
     version: Option<u8>,
 ) -> Result<usize> {
     use sha2::{Digest, Sha256};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,8 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-mod alphabet;
+pub mod alphabet;
+#[doc(inline)]
 pub use alphabet::Alphabet;
 
 pub mod decode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![warn(variant_size_differences)]
+#![doc(test(attr(deny(warnings))))]
 
 //! Another [Base58][] codec implementation.
 //!
@@ -66,9 +67,9 @@
 //! ```rust
 //! let (mut decoded, mut encoded) = ([0xFF; 8], String::with_capacity(10));
 //! bs58::decode("he11owor1d").into(&mut decoded)?;
-//! bs58::encode(decoded).into(&mut encoded);
+//! bs58::encode(decoded).into(&mut encoded)?;
 //! assert_eq!("he11owor1d", encoded);
-//! # Ok::<(), bs58::decode::Error>(())
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
 #[cfg(feature = "std")]
@@ -188,8 +189,9 @@ pub fn decode<I: AsRef<[u8]>>(input: I) -> decode::DecodeBuilder<'static, I> {
 /// ```rust
 /// let input = [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58];
 /// let mut output = "goodbye world".to_owned();
-/// bs58::encode(input).into(&mut output);
+/// bs58::encode(input).into(&mut output)?;
 /// assert_eq!("he11owor1d", output);
+/// # Ok::<(), bs58::encode::Error>(())
 /// ```
 ///
 /// ## Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,8 @@ enum Check {
 /// ### Too Small Buffer
 ///
 /// This error can only occur when reading into a provided buffer, when using
-/// `.into_vec` a vector large enough is guaranteed to be used.
+/// [`into_vec()`][decode::DecodeBuilder::into_vec] a vector large enough is guaranteed to be
+/// used.
 ///
 /// ```rust
 /// let mut output = [0; 7];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,11 @@
 //!
 //! ```rust
 //! let decoded = bs58::decode("he11owor1d")
-//!     .with_alphabet(bs58::alphabet::RIPPLE)
+//!     .with_alphabet(bs58::Alphabet::RIPPLE)
 //!     .into_vec()
 //!     .unwrap();
 //! let encoded = bs58::encode(decoded)
-//!     .with_alphabet(bs58::alphabet::FLICKR)
+//!     .with_alphabet(bs58::Alphabet::FLICKR)
 //!     .into_string();
 //! assert_eq!("4DSSNaN1SC", encoded);
 //! ```
@@ -75,7 +75,7 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-pub mod alphabet;
+mod alphabet;
 pub use alphabet::Alphabet;
 
 pub mod decode;
@@ -91,9 +91,7 @@ enum Check {
     Enabled(Option<u8>),
 }
 
-/// Setup decoder for the given string using the [default alphabet][].
-///
-/// [default alphabet]: alphabet/constant.DEFAULT.html
+/// Setup decoder for the given string using the [default alphabet][Alphabet::DEFAULT].
 ///
 /// # Examples
 ///
@@ -111,7 +109,7 @@ enum Check {
 /// assert_eq!(
 ///     vec![0x60, 0x65, 0xe7, 0x9b, 0xba, 0x2f, 0x78],
 ///     bs58::decode("he11owor1d")
-///         .with_alphabet(bs58::alphabet::RIPPLE)
+///         .with_alphabet(bs58::Alphabet::RIPPLE)
 ///         .into_vec().unwrap());
 /// ```
 ///
@@ -158,9 +156,7 @@ pub fn decode<I: AsRef<[u8]>>(input: I) -> decode::DecodeBuilder<'static, I> {
     decode::DecodeBuilder::from_input(input)
 }
 
-/// Setup encoder for the given bytes using the [default alphabet][].
-///
-/// [default alphabet]: alphabet/constant.DEFAULT.html
+/// Setup encoder for the given bytes using the [default alphabet][Alphabet::DEFAULT].
 ///
 /// # Examples
 ///
@@ -178,7 +174,7 @@ pub fn decode<I: AsRef<[u8]>>(input: I) -> decode::DecodeBuilder<'static, I> {
 /// assert_eq!(
 ///     "he11owor1d",
 ///     bs58::encode(input)
-///         .with_alphabet(bs58::alphabet::RIPPLE)
+///         .with_alphabet(bs58::Alphabet::RIPPLE)
 ///         .into_string());
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,10 @@
 //!
 //! ```rust
 //! let decoded = bs58::decode("he11owor1d")
-//!     .with_alphabet(bs58::Alphabet::RIPPLE)
+//!     .with_alphabet(&bs58::Alphabet::RIPPLE)
 //!     .into_vec()?;
 //! let encoded = bs58::encode(decoded)
-//!     .with_alphabet(bs58::Alphabet::FLICKR)
+//!     .with_alphabet(&bs58::Alphabet::FLICKR)
 //!     .into_string();
 //! assert_eq!("4DSSNaN1SC", encoded);
 //! # Ok::<(), bs58::decode::Error>(())
@@ -113,7 +113,7 @@ enum Check {
 /// assert_eq!(
 ///     vec![0x60, 0x65, 0xe7, 0x9b, 0xba, 0x2f, 0x78],
 ///     bs58::decode("he11owor1d")
-///         .with_alphabet(bs58::Alphabet::RIPPLE)
+///         .with_alphabet(&bs58::Alphabet::RIPPLE)
 ///         .into_vec()?);
 /// # Ok::<(), bs58::decode::Error>(())
 /// ```
@@ -181,7 +181,7 @@ pub fn decode<I: AsRef<[u8]>>(input: I) -> decode::DecodeBuilder<'static, I> {
 /// assert_eq!(
 ///     "he11owor1d",
 ///     bs58::encode(input)
-///         .with_alphabet(bs58::Alphabet::RIPPLE)
+///         .with_alphabet(&bs58::Alphabet::RIPPLE)
 ///         .into_string());
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,10 @@
 //! ## Basic example
 //!
 //! ```rust
-//! let decoded = bs58::decode("he11owor1d").into_vec().unwrap();
+//! let decoded = bs58::decode("he11owor1d").into_vec()?;
 //! let encoded = bs58::encode(decoded).into_string();
 //! assert_eq!("he11owor1d", encoded);
+//! # Ok::<(), bs58::decode::Error>(())
 //! ```
 //!
 //! ## Changing the alphabet
@@ -52,21 +53,22 @@
 //! ```rust
 //! let decoded = bs58::decode("he11owor1d")
 //!     .with_alphabet(bs58::Alphabet::RIPPLE)
-//!     .into_vec()
-//!     .unwrap();
+//!     .into_vec()?;
 //! let encoded = bs58::encode(decoded)
 //!     .with_alphabet(bs58::Alphabet::FLICKR)
 //!     .into_string();
 //! assert_eq!("4DSSNaN1SC", encoded);
+//! # Ok::<(), bs58::decode::Error>(())
 //! ```
 //!
 //! ## Decoding into an existing buffer
 //!
 //! ```rust
 //! let (mut decoded, mut encoded) = ([0xFF; 8], String::with_capacity(10));
-//! bs58::decode("he11owor1d").into(&mut decoded).unwrap();
+//! bs58::decode("he11owor1d").into(&mut decoded)?;
 //! bs58::encode(decoded).into(&mut encoded);
 //! assert_eq!("he11owor1d", encoded);
+//! # Ok::<(), bs58::decode::Error>(())
 //! ```
 
 #[cfg(feature = "std")]
@@ -100,7 +102,8 @@ enum Check {
 /// ```rust
 /// assert_eq!(
 ///     vec![0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58],
-///     bs58::decode("he11owor1d").into_vec().unwrap());
+///     bs58::decode("he11owor1d").into_vec()?);
+/// # Ok::<(), bs58::decode::Error>(())
 /// ```
 ///
 /// ## Changing the alphabet
@@ -110,17 +113,19 @@ enum Check {
 ///     vec![0x60, 0x65, 0xe7, 0x9b, 0xba, 0x2f, 0x78],
 ///     bs58::decode("he11owor1d")
 ///         .with_alphabet(bs58::Alphabet::RIPPLE)
-///         .into_vec().unwrap());
+///         .into_vec()?);
+/// # Ok::<(), bs58::decode::Error>(())
 /// ```
 ///
 /// ## Decoding into an existing buffer
 ///
 /// ```rust
 /// let mut output = [0xFF; 10];
-/// assert_eq!(8, bs58::decode("he11owor1d").into(&mut output).unwrap());
+/// assert_eq!(8, bs58::decode("he11owor1d").into(&mut output)?);
 /// assert_eq!(
 ///     [0x04, 0x30, 0x5e, 0x2b, 0x24, 0x73, 0xf0, 0x58, 0xFF, 0xFF],
 ///     output);
+/// # Ok::<(), bs58::decode::Error>(())
 /// ```
 ///
 /// ## Errors


### PR DESCRIPTION
Remove non-prepared alphabet support and use new compiler features.

fixes #53