### PR TITLE
CLI: Trim trailing whitespace

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,16 +79,19 @@ struct Args {
     alphabet: Alphabet,
 }
 
+const INITIAL_INPUT_CAPACITY: usize = 4096;
 #[paw::main]
 fn main(args: Args) -> anyhow::Result<()> {
-    let mut input = Vec::with_capacity(4096);
-    io::stdin().read_to_end(&mut input)?;
     if args.decode {
-        let output = bs58::decode(input)
+        let mut input = String::with_capacity(INITIAL_INPUT_CAPACITY);
+        io::stdin().read_to_string(&mut input)?;
+        let output = bs58::decode(trimmed)
             .with_alphabet(args.alphabet.as_bytes())
             .into_vec()?;
         io::stdout().write_all(&output)?;
     } else {
+        let mut input = Vec::with_capacity(INITIAL_INPUT_CAPACITY);
+        io::stdin().read_to_end(&mut input)?;
         let output = bs58::encode(input)
             .with_alphabet(args.alphabet.as_bytes())
             .into_string();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -85,6 +85,7 @@ fn main(args: Args) -> anyhow::Result<()> {
     if args.decode {
         let mut input = String::with_capacity(INITIAL_INPUT_CAPACITY);
         io::stdin().read_to_string(&mut input)?;
+        let trimmed = input.trim_end();
         let output = bs58::decode(trimmed)
             .with_alphabet(args.alphabet.as_bytes())
             .into_vec()?;


### PR DESCRIPTION
CLI doesn't trim whitespace from EOL of decode input, resulting in error.  This makes it impossible to use the utility with herestrings
```
$ bs58 -d <<<"ohnonew1ine"
Error: provided string contained invalid character '\n' at byte 11
```