### PR TITLE
Fix `unsizing casts are not allowed in const fn`

### DIFF
--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -104,7 +104,7 @@ impl Alphabet {
         let mut decode = [0xFF; 128];
 
         let mut i = 0;
-        while i < encode.len() {
+        while i < 58 {
             if base[i] >= 128 {
                 return Err(Error::NonAsciiCharacter { index: i });
             }


### PR DESCRIPTION
On rust nightly `nightly-2020-07-10-x86_64-unknown-linux-gnu`, I get the following error:

```
error[E0723]: unsizing casts are not allowed in const fn
   --> src/alphabet.rs:107:19
    |
107 |         while i < encode.len() {
    |                   ^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable

error: aborting due to previous error
```

This PR fixes this issue.