### PR TITLE
Return length during const decoding

### DIFF
--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -81,6 +81,12 @@ fn test_decode_const_small_buffer_panic() {
 }
 
 #[test]
+fn test_decode_const_large_buffer() {
+    let (_, length) = bs58::decode(&b"a3gV"[..]).into_array_with_length_const_unwrap::<4>();
+    assert_eq!(length, 3);
+}
+
+#[test]
 #[should_panic]
 fn test_decode_const_invalid_char_panic() {
     let sample = "123456789abcd!efghij";


### PR DESCRIPTION
#### Problem

The current API for const-decoding only returns the resulting array, which makes it impossible for a user to check that the input had the correct length. This is an important use-case for things like wallet addresses, where people often make typos by forgetting to paste a character.

#### Proposed changes

Since there's no `onto()` API available in const contexts, this PR introduces a breaking change by having `into_array_const` also return the length decoded. I couldn't come up with a way to eliminate the breaking change without also introducing a lot of copied code, since we can't call `Result::map` in a const context.

I apologize for coming back with another change so soon, but I only discovered the issue when playing around with the API more recently. Let me know what you think!