### PR TITLE
Implement `core::error::Error` for error types by default

### DIFF
--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -77,7 +77,7 @@ impl Alphabet {
     ///     .into_string();
     ///
     /// assert_eq!("#ERRN)N RD", encoded);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
     /// ## Errors
     ///
@@ -140,7 +140,7 @@ impl Alphabet {
     ///     .into_string();
     ///
     /// assert_eq!("#ERRN)N RD", encoded);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
     ///
     /// If your alphabet is inconsistent then this will fail to compile in a `const` context:
@@ -170,8 +170,7 @@ impl fmt::Debug for Alphabet {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -603,8 +603,7 @@ const fn decode_into_const<const N: usize>(input: &[u8], alpha: &Alphabet) -> Re
     Ok(output)
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -351,7 +351,7 @@ impl<'a, I: AsRef<[u8]>> DecodeBuilder<'a, I> {
 /// For `const` compatibility we are restricted to using a concrete input and output type, as
 /// `const` trait implementations and `&mut` are unstable. These methods will eventually be
 /// deprecated once the primary interfaces can be converted into `const fn` directly.
-impl<'a, 'b> DecodeBuilder<'a, &'b [u8]> {
+impl DecodeBuilder<'_, &[u8]> {
     /// Decode into a new array.
     ///
     /// Returns the decoded array as bytes.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -518,8 +518,7 @@ fn encode_cb58_into(
     )
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! bs58::decode("he11owor1d").onto(&mut decoded)?;
 //! bs58::encode(decoded).onto(&mut encoded)?;
 //! assert_eq!("he11owor1d", encoded);
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # Ok::<(), Box<dyn core::error::Error>>(())
 //! ```
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This PR updates the code to implement `core::error::Error` for error types by default.

`core::error::Error` has been stabilized since [rust-1.81.0](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#coreerrorerror).